### PR TITLE
Fixed Sublime 3 download and changed url for atom

### DIFF
--- a/atom.yml
+++ b/atom.yml
@@ -4,6 +4,6 @@
   tasks:
     - name: install atom
       mac_pkg: pkg_type=app
-               url=https://s3.amazonaws.com/github-cloud/releases/3228505/ba353ca2-b775-11e4-9d27-7a45c001864f.zip?response-content-disposition=attachment%3B%20filename%3Datom-mac.zip&response-content-type=application/octet-stream&AWSAccessKeyId=AKIAISTNZFOVBIJMK3TQ&Expires=1424411516&Signature=YbfZsKNELIiE%2BTeTJr3y%2FlrXV04%3D
-               archive_type=zip archive_path='Atom.app'
+               url=https://atom.io/download/mac
+               curl_opts="-L" archive_type=zip archive_path='Atom.app'
       sudo: yes

--- a/atom.yml
+++ b/atom.yml
@@ -5,5 +5,5 @@
     - name: install atom
       mac_pkg: pkg_type=app
                url=https://atom.io/download/mac
-               curl_opts="-L" archive_type=zip archive_path='Atom.app'
+               archive_type=zip archive_path='Atom.app'
       sudo: yes

--- a/charles.yml
+++ b/charles.yml
@@ -1,0 +1,9 @@
+---
+- hosts: workstation
+
+  tasks:
+    - name: install charles
+      mac_pkg: pkg_type=app
+               url=http://www.charlesproxy.com/assets/release/3.10.1/charles-proxy-3.10.1.dmg
+               archive_type=dmg archive_path='Charles.app'
+      sudo: yes

--- a/sublime3.yml
+++ b/sublime3.yml
@@ -4,6 +4,6 @@
   tasks:
     - name: install sublime 3
       mac_pkg: pkg_type=app
-               url=http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203065.dmg
+               url=http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203083.dmg
                archive_type=dmg archive_path='Sublime Text.app'
       sudo: yes

--- a/sublime3.yml
+++ b/sublime3.yml
@@ -5,5 +5,5 @@
     - name: install sublime 3
       mac_pkg: pkg_type=app
                url=http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203065.dmg
-               archive_type=dmg archive_path='Sublime Text'
+               archive_type=dmg archive_path='Sublime Text.app'
       sudo: yes


### PR DESCRIPTION
Sublime Text 3 did not include a .app extension and was an older version.  Updated that.

Not sure why atom.app is not installing, but this url is better than the one given.